### PR TITLE
Add initial state transferred message

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.aspiralimited.oddsmarket</groupId>
     <artifactId>client</artifactId>
-    <version>4.7.1</version>
+    <version>4.7.2</version>
 
 
     <properties>

--- a/client/src/main/java/com/aspiralimited/oddsmarket/client/v4/websocket/handlers/Handler.java
+++ b/client/src/main/java/com/aspiralimited/oddsmarket/client/v4/websocket/handlers/Handler.java
@@ -62,6 +62,10 @@ public abstract class Handler {
                 internalRemoveBookmakerEvents(bookmakerEventIds);
                 break;
 
+            case "initial_state_transferred":
+                initialStateTransferred();
+                break;
+
             case "subscribed":
                 internalInfo("Subscribed successfully: " + jsonMsg);
                 break;
@@ -104,6 +108,8 @@ public abstract class Handler {
     public abstract void outcomes(List<OutcomeDto> updatedOutcomeDtos);
 
     public abstract void removeBookmakerEvents(Collection<Long> bookmakerEventIds);
+
+    public abstract void initialStateTransferred();
 
     public abstract void onDisconnected(boolean closedByServer);
 }


### PR DESCRIPTION
### `initial_state_transferred` response message

Message indicates that initial state of bookmaker events and outcomes has been transferred.
It means that after receiving this message you have received all bookmaker events and outcomes
that were available at the moment of subscription.

Example:

```
{"msg": "", "cmd": "initial_state_transferred"}
```